### PR TITLE
20241210

### DIFF
--- a/libs/src/ChangeLog.md
+++ b/libs/src/ChangeLog.md
@@ -1,11 +1,43 @@
-## V1.0.0 (2024-12-09)
+## V1.0.0 (2024-12-10)
 
 ---
 
 🆙update：Accordion
 
 - 同步學長 CSS
-- 改寫新的 HTML 結構
+- 改寫新的 HTML 結構（Amos 版）
 - 重寫 storybook
+
+🆙update：AvatarGroup
+
+- class name 多了 text-large  (20241209 done)
+- 程式運作方式，要改成跟 kevin 一樣變數 number 不轉 string (20241209 done)
+- 採用 list 組件，請參考 Kevin 的 HTML 結構 (20241209 done)
+
+🆙update：Dialog
+
+- 參考 Kevin 的呈現方式 (20241209 done)
+- class 變更 (20241209 done)
+- 變更色彩為 primary (20241209 done) -「Title」不用給標題標籤 (20241209 done)
+- 點擊按鈕後跳出 alert 讓開發者可以知道目前點擊到的項目，避免誤解是其他物件的事件導致關閉 dialog (20241209 done)
+- 改「header」，描述改「標題」 (20241209 done)
+- 改「content」，描述改「內容」 (20241209 done)
+- 改「footer」，描述改「附註」 (20241209 done)
+- 參照 kevin 的參數製作 (20241209 done) (vue 版 isOpen 統一由 compoasable 控制 因此不會出現在 props 中～～ )
+
+🆙update：Divider
+
+- 同步學長 CSS
+- None 的 N 改 小寫「n」 (20241209 done)
+- 直式的把線添加 min-height: 5em (20241209 done)
+
+🆙update：List
+
+- dataSource 加上必填星號 (20241209 done)
+- 選單樣式壞了，請修正 (20241209 done)
+
+🆙update：Input
+
+- 輸入資料後這邊的行為應該會一致出現「Ｘ」，但密碼則會出現「刪除及眼睛」圖示(20241209 done)
 
 ---

--- a/libs/src/style/component/element/_accordion.scss
+++ b/libs/src/style/component/element/_accordion.scss
@@ -28,8 +28,8 @@
         }
     }
 
-    details {
-        .ded-detail-title {
+    .ded-accordion-detail {
+        .ded-accordion-title {
             display: flex;
             justify-content: space-between;
             align-items: center;

--- a/libs/src/style/component/element/_avatar.scss
+++ b/libs/src/style/component/element/_avatar.scss
@@ -1,10 +1,10 @@
-
 @use 'sass:map';
 
 .ded-avatar-container {
     position: relative;
     box-shadow: 0 0 0 2px $color-white;
     border-radius: 50%;
+    box-sizing: border-box;
 }
 
 .ded-avatar {

--- a/libs/src/style/component/element/_avatar_group.scss
+++ b/libs/src/style/component/element/_avatar_group.scss
@@ -4,10 +4,29 @@
   gap: 8px;
   position: relative;
 
-  .ded-avatar-container {
-    &:not(:first-child) {
-      margin-left: -20px;
-    }
+  &-container {
+    position: relative;
+    margin-left: -20px;
   }
 }
 
+.ded-avatar-container {
+  &:not(:first-child) {
+    margin-left: -20px;
+  }
+}
+
+
+// jony 自訂 class
+.rest-container {
+  position: relative;
+  margin-left: -20px;
+
+  &-menu {
+    position: absolute;
+    top: calc(100% + 8px);
+    left: -50%;
+    min-width: 200px;
+    border-radius: 4px;
+  }
+}

--- a/libs/src/style/component/element/_divider.scss
+++ b/libs/src/style/component/element/_divider.scss
@@ -5,11 +5,14 @@
     --line-weight: 2px;
     --line-style: solid;
     display: flex;
+    min-height: 5em;
 }
+
 /*--- Divider 方向 ---*/
 .ded-divider-horizontal {
     align-items: center;
 }
+
 .ded-divider-vertical {
     flex-direction: column;
     align-items: center;
@@ -38,15 +41,19 @@
 .ded-divider-width-xsmall {
     --line-weight: 1px;
 }
+
 .ded-divider-width-small {
     --line-weight: 2px;
 }
+
 .ded-divider-width-medium {
     --line-weight: 4px;
 }
+
 .ded-divider-width-large {
     --line-weight: 6px;
 }
+
 .ded-divider-width-xlarge {
     --line-weight: 8px;
 }
@@ -55,9 +62,11 @@
 .ded-divider-solid {
     --line-style: solid;
 }
+
 .ded-divider-dashed {
     --line-style: dashed;
 }
+
 .ded-divider-dotted {
     --line-style: dotted;
 }
@@ -73,6 +82,7 @@
     flex-grow: 0;
     width: 1rem;
 }
+
 .ded-divider-end.ded-divider-horizontal::after {
     flex-grow: 0;
     width: 1rem;
@@ -83,6 +93,7 @@
     flex-grow: 0;
     height: 1rem;
 }
+
 .ded-divider-end.ded-divider-vertical::after {
     flex-grow: 0;
     height: 1rem;
@@ -92,14 +103,17 @@
     .ded-divider-#{$theme}.ded-divider-vertical::before {
         border-left-color: getThemeColor($mode, $theme, "default");
     }
+
     .ded-divider-#{$theme}.ded-divider-vertical::after {
         border-left-color: getThemeColor($mode, $theme, "default");
     }
 }
+
 @each $theme in $themes {
     .ded-divider-#{$theme}.ded-divider-horizontal::before {
         border-top-color: getThemeColor($mode, $theme, "default");
     }
+
     .ded-divider-#{$theme}.ded-divider-horizontal::after {
         border-top-color: getThemeColor($mode, $theme, "default");
     }

--- a/libs/src/ui/element/Accordion/Accordion.vue
+++ b/libs/src/ui/element/Accordion/Accordion.vue
@@ -6,7 +6,6 @@ const props = defineProps({
 	dataSource: {
 		type: Array,
 		required: true,
-		default: () => [],
 	},
 	isOpenAll: {
 		type: Boolean,
@@ -23,15 +22,18 @@ const allOpen = computed(() => props.isOpenAll);
 </script>
 
 <template>
-	<ul :class="{'ded-accordion': true, [props.className]: !!props.className}">
-		<AccordionItem
-			v-for="item in dataSource"
-			:key="item.id"
-			:label="item.label"
-			:detail="item.detail"
-			:isOpen="allOpen"
-		/>
-	</ul>
+	<div class="ded-accordion-container">
+		<ul :class="{'ded-accordion': true, [props.className]: !!props.className}">
+			<AccordionItem
+				v-for="item in dataSource"
+				:key="item.id"
+				:label="item.label"
+				:detail="item.detail"
+				:isOpen="allOpen"
+			/>
+		</ul>
+	</div>
+
 </template>
 
 <style scoped lang="scss">

--- a/libs/src/ui/element/Accordion/AccordionItem.vue
+++ b/libs/src/ui/element/Accordion/AccordionItem.vue
@@ -70,14 +70,14 @@ onBeforeUnmount(() => {
 
 <template>
 	<li class="ded-accordion-item">
-		<details :open="isItemOpen" :class="{'detail': true, [props.className]: !!props.className}" @toggle="handleToggle">
-			<summary class="ded-detail-title">
+		<details :open="isItemOpen" :class="{'ded-accordion-detail ': true, [props.className]: !!props.className}" @toggle="handleToggle">
+			<summary class="ded-accordion-title">
 				<span>{{ label }}</span>
-				<div :class="isItemOpen ? 'accordion-item-open' : 'accordion-item-close'">
+				<div :class="isItemOpen ? 'ded-accordion-item-open' : 'ded-accordion-item-close'" class="ded-icon-medium">
 					<Icon size="24" name="arrow_down"/>
 				</div>
 			</summary>
-			<div class="detail-content">
+			<div class="ded-detail-content">
 				<p>{{ detail }}</p>
 			</div>
 		</details>

--- a/libs/src/ui/element/Avatar/Avatar.vue
+++ b/libs/src/ui/element/Avatar/Avatar.vue
@@ -68,7 +68,8 @@ const getInitialsOrDefault = (string, count) => {
 			</template>
 			<template v-else>
 				<span
-					:class="['ded-avatar-text', `text-${props.size}`]">{{ getInitialsOrDefault(props.userName, 2) }}</span>
+					:class="['ded-avatar-text', `ded-text-${props.size}`]">{{ getInitialsOrDefault(props.userName, 2)
+					}}</span>
 			</template>
 		</div>
 		<AvatarStatus :avatarStatus="props.status" :avatarSize="props.size"></AvatarStatus>

--- a/libs/src/ui/element/AvatarGroup/AvatarGroup.vue
+++ b/libs/src/ui/element/AvatarGroup/AvatarGroup.vue
@@ -65,29 +65,47 @@ const handleClick = () => {
 		updateMenuPosition();
 		window.addEventListener('resize', updateMenuPosition);
 		window.addEventListener('scroll', updateMenuPosition, true);
+		document.addEventListener('click', handleOutsideClick); // 新增
 	} else {
 		window.removeEventListener('resize', updateMenuPosition);
 		window.removeEventListener('scroll', updateMenuPosition, true);
+		document.removeEventListener('click', handleOutsideClick); // 新增
 	}
 };
+
+// 點擊外部時關閉菜單
+const handleOutsideClick = (event) => {
+	const menuElement = document.querySelector('.ded-dropdown-menu');
+	if (
+		restContainerRef.value &&
+		!restContainerRef.value.contains(event.target) &&
+		(!menuElement || !menuElement.contains(event.target))
+	) {
+		isOpen.value = false;
+		document.removeEventListener('click', handleOutsideClick);
+	}
+};
+
 
 // 清理事件監聽器
 onMounted(() => {
 	if (isOpen.value) {
 		window.addEventListener('resize', updateMenuPosition);
 		window.addEventListener('scroll', updateMenuPosition, true);
+		document.addEventListener('click', handleOutsideClick); // 確保 Mounted 時的事件監聽
 	}
 });
 
 onBeforeUnmount(() => {
 	window.removeEventListener('resize', updateMenuPosition);
 	window.removeEventListener('scroll', updateMenuPosition, true);
+	document.removeEventListener('click', handleOutsideClick); // 確保清理
 });
 </script>
 
+
 <template>
 	<div :class="{'ded-avatar-group': true,[props.className]: !!props.className,}">
-		<!-- avatar group - 渲染 avatar -->
 		<Avatar
 			v-for="(avatar, index) in currList"
 			:key="index"
@@ -97,23 +115,19 @@ onBeforeUnmount(() => {
 			:userName="avatar.userName"
 		></Avatar>
 
-		<div class="rest-container" ref="restContainerRef" v-if="restList.length > 0">
-
-			<!-- avatar group - 剩餘未顯示總數表示 -->
-			<div v-if="restList.length > 0" :class="[ 'ded-avatar-container', props.size ?
+		<template  v-if="restList.length > 0">
+			<div ref="restContainerRef" v-if="restList.length > 0" :class="[ 'ded-avatar-container', props.size ?
 			`ded-avatar-container-${props.size}` : 'ded-avatar-container-medium' ]">
 				<button
 					:class="[ 'ded-avatar', props.shape ? `ded-avatar-${props.shape}` : 'ded-avatar-circle' ]"
 					@click.prevent="handleClick"
-					style="cursor: pointer"
 				>
-                    <span :class="[ 'ded-avatar-text', props.size ? `text-${props.size}` : 'text-medium' ]">
+                    <span class="ded-avatar-text">
                         {{ `+${restCount}` }}
                     </span>
 				</button>
 			</div>
 
-			<!-- 使用 Teleport 將 rest-container-menu 傳送到 body -->
 			<Teleport to="body">
 				<div
 					v-if="isOpen"
@@ -122,20 +136,21 @@ onBeforeUnmount(() => {
                         position: 'absolute',
                         top: menuStyles.top,
                         left: menuStyles.left,
-                        zIndex: 9999,
+                        'z-index': 9999
                     }"
 				>
 
 					<List :hasOutline="true">
-						<li class="ded-list-item" v-for="(menu) in restList" :key="menu.userName" style="border-bottom:
-						none">
+						<li class="ded-list-item" v-for="(menu) in restList" :key="menu.userName">
 							<div class="ded-list-item-text">
-								<Avatar
-									size="xsmall"
-									:src="menu.src"
-									alt="alt text"
-									:userName="menu.userName"
-								></Avatar>
+								<div class="ded-list-icon">
+									<Avatar
+										size="xsmall"
+										:src="menu.src"
+										alt="alt text"
+										:userName="menu.userName"
+									></Avatar>
+								</div>
 								<div data-v-2ddf7f21="" class="ded-list-item-label">
 									{{ menu.userName }}
 								</div>
@@ -145,7 +160,7 @@ onBeforeUnmount(() => {
 
 				</div>
 			</Teleport>
-		</div>
+		</template>
 	</div>
 </template>
 

--- a/libs/src/ui/element/Badge/Badge.vue
+++ b/libs/src/ui/element/Badge/Badge.vue
@@ -37,8 +37,7 @@ const props = defineProps({
 
 // 計算是否大於對大設定值
 const computedValue = computed(() => {
-	const isNumBadgeLabel = typeof(+props.value) === 'number' || !isNaN(+props.value);
-	if (isNumBadgeLabel) {
+	if (props.value > props.limit) {
 		return (props.value > props.limit) ? props.limit : props.value
 	}
 	return props.value

--- a/libs/src/ui/element/Dialog/Dialog.stories.js
+++ b/libs/src/ui/element/Dialog/Dialog.stories.js
@@ -10,14 +10,6 @@ export default {
 	component: Dialog,
 	tags: ["autodocs"],
 	argTypes: {
-		// title: {
-		// 	description: "標題",
-		// 	control: { type: "text" },
-		// },
-		// content: {
-		// 	description: "內容",
-		// 	control: { type: "text" },
-		// },
 		hasClose: {
 			description:"是否有關閉按鈕",
 			control: { type: "boolean" },
@@ -26,7 +18,7 @@ export default {
 			description: "客製化樣式",
 			control: { type: "text" },
 		},
-		title: {
+		header: {
 			description: "標題",
 			control: { type: "text" },
 			table: {
@@ -51,7 +43,7 @@ export default {
 			},
 		},
 		footer: {
-			description: "footer 插槽",
+			description: "附註",
 			control: { type: "text" },
 
 			table: {
@@ -79,7 +71,7 @@ export const DialogDefault = {
 	args: {
 		hasClose: false,
 		className: '',
-		title: 'Title',
+		header: 'Title',
 		content: 'Content',
 	},
 	render: (args) => ({
@@ -112,7 +104,7 @@ export const DialogDefault = {
 					<Icon name="close" size="20"></Icon>
 				</button>
 				<div class="ded-dialog-header">
-					{{ args.title }}
+					{{ args.header }}
 				</div>
 				<div class="ded-dialog-body">
 					{{ args.content }}
@@ -170,10 +162,11 @@ export const DialogDefault = {
 };
 
 
-//==== Demo ====//
+//==== 互動模式 ====//
 export const DialogDemo = {
-	name: "Demo",
+	name: "互動模式",
 	args: {
+		content: 'Content',
 		hasClose: true,
 		className: '',
 	},
@@ -181,6 +174,10 @@ export const DialogDemo = {
 		components: { Dialog, Button, Title },
 		setup() {
 			const dialog = useDialog();
+			const onClose = () => {
+				window.alert('Close');
+				dialog.closeDialog(); // 關閉對話框
+			};
 			const onConfirm = () => {
 				window.alert('OK');
 				dialog.closeDialog(); // 關閉對話框
@@ -192,21 +189,23 @@ export const DialogDemo = {
 			return {
 				args,
 				dialog,
+				onClose,
 				onConfirm,
 				onCancel
 			}
 		},
 		template: `
 			<Dialog
-				title=""
-				:content="args.content"
 				:hasClose="args.hasClose"
 				className=""
 			>
-				<template #title>
-					<Title level="3">Title</Title>
+				<template #header>
+					<Title :level="3">Title</Title>
 				</template>
-				<template #footert>
+				<template #content>
+					<p>Content</p>
+				</template>
+				<template #footer>
 					<Button variant="contained" size="medium" class="ded-cancel-btn" @click="onCancel">
 						Cancel
 					</Button>
@@ -240,13 +239,14 @@ export const DialogDemo = {
 						`const dialog = useDialog();`,
 						'',
 						'<Dialog',
-						'  title=""',
-						'  :content="${args.content}"',
 						'  :hasClose="${args.hasClose}"',
 						'  className=""',
 						'>',
 						'  <template #title>',
 						'    <Title level="3">Title</Title>',
+						'  </template>',
+						'  <template #content>',
+						'    <p>Content</p>',
 						'  </template>',
 						'  <template #footer>',
 						'    <Button',

--- a/libs/src/ui/element/Dialog/Dialog.vue
+++ b/libs/src/ui/element/Dialog/Dialog.vue
@@ -12,14 +12,6 @@ const props = defineProps({
 		type: Boolean,
 		default: false,
 	},
-	// title: {
-	// 	type: String,
-	// 	default: "Title",
-	// },
-	// content: {
-	// 	type: String,
-	// 	default: "Content",
-	// },
 	className: {
 		type: String,
 		default: "",
@@ -43,14 +35,14 @@ const props = defineProps({
 					</template>
 
 					<div class="ded-dialog-header">
-						<slot name="title">
-							{{ props.title }}
+						<slot name="header">
+<!--							{{ props.title }}-->
 						</slot>
 					</div>
 
 					<div class="ded-dialog-body">
 						<slot name="content">
-							{{ props.content }}
+<!--							{{ props.content }}-->
 						</slot>
 					</div>
 

--- a/libs/src/ui/element/Divider/Divider.stories.js
+++ b/libs/src/ui/element/Divider/Divider.stories.js
@@ -10,7 +10,7 @@ export default {
             control: {
                 type: "select",
                 labels: {
-                    "": "None",
+                    "": "none",
                     primary: "primary",
                     secondary: "secondary",
                     tertiary: "tertiary",
@@ -118,8 +118,6 @@ export const DividerDefault = {
             };
         },
         template: `
-			<div style="display:flex;  justify-content:center; gap: 16px; height: 200px"
-                :style="args.direction === 'horizontal'? 'flex-direction: column;': ''">
 				<Divider
 					:themeColor="args.themeColor"
 					:width="args.width"
@@ -128,7 +126,6 @@ export const DividerDefault = {
 					:align="args.align"
                     :className="args.className"
 				>{{args.default}}</Divider>
-			</div>
 		`,
     }),
     // 控制 controls 中能控制的參數

--- a/libs/src/ui/element/Divider/Divider.vue
+++ b/libs/src/ui/element/Divider/Divider.vue
@@ -60,7 +60,7 @@ const props = defineProps({
         ]"
     >
         <!-- divider - 分隔線文字 -->
-	    <template v-if="$slots.default && $slots.default().some(vnode => vnode.children?.trim())">
+	    <template v-if="$slots.default && $slots.default().some(node => node.children?.trim())">
 		    <div class="ded-divider-content">
 			    <slot></slot>
 		    </div>

--- a/libs/src/ui/element/Input/Input.vue
+++ b/libs/src/ui/element/Input/Input.vue
@@ -23,10 +23,6 @@ const props = defineProps({
 		type: String,
 		default: "",
 	},
-	// suffix: {
-	// 	type: String,
-	// 	default: "",
-	// },
 	size: {
 		type: String,
 		default: "medium",
@@ -105,7 +101,7 @@ const togglePasswordVisibility = () => {
 			<!-- Suffix Icons -->
 			<template v-if=" modelValue || props.type === 'password'">
 				<!-- input type 等於 text -->
-				<div v-if="modelValue && props.type === 'text'" :class="`ded-icon-${props.size}`"
+				<div v-if="modelValue && props.type !== 'password'" :class="`ded-icon-${props.size}`"
 				     @click="clearInput">
 					<Icon name="close" />
 				</div>

--- a/libs/src/ui/element/List/List.stories.js
+++ b/libs/src/ui/element/List/List.stories.js
@@ -20,6 +20,11 @@ export default {
 		dataSource: {
 			description: "資料來源",
 			control: { type: 'object' },
+			table: {
+				type: {
+					summary: '{ label: string; value: string; href: string; prefix: string;}[]',
+				}
+			}
 		},
 		hasOutline: {
 			description: "是否為選單",
@@ -78,17 +83,11 @@ export const ListDefaultStory = {
 		},
 		template: `
 			<List
+				:dataSource="args.dataSource"
 				:hasOutline="args.hasOutline"
 				:className="args.className"
 			>
-				<ListItem
-					v-for="(item, index) in args.dataSource"
-					:key="index"
-					:label="item.label"
-					:value="item.value"
-					:href="item.href"
-					:prefix="item.prefix"
-				></ListItem>
+				
 			</List>
         `,
 	}),
@@ -122,28 +121,22 @@ export const ListTypeStory = {
 	args: {
 		dataSource:[
 			{
-				"content": {
-					"label": "選項一",
-					"value": "option1",
-					"href": "",
-					"prefix": "folder"
-				}
+				"label": "Option1",
+				"value": "option1",
+				"href": "",
+				"prefix": "home"
 			},
 			{
-				"content": {
-					"label": "選項二",
-					"value": "option2",
-					"href": "",
-					"prefix": "home"
-				}
+				"label": "Option2",
+				"value": "option2",
+				"href": "#",
+				"prefix": "users"
 			},
 			{
-				"content": {
-					"label": "選項三",
-					"value": "option3",
-					"href": "www.google.com",
-					"prefix": "folder"
-				}
+				"label": "Option3",
+				"value": "option3",
+				"href": "#",
+				"prefix": "folder"
 			},
 		],
 		className: 'col-5',
@@ -158,7 +151,7 @@ export const ListTypeStory = {
 		template: `
 			<List
 				:dataSource="args.dataSource"
-				:hasOutline="true"
+				:hasOutline=true
 				:className="args.className"
 			>
 			</List>

--- a/libs/src/ui/element/List/List.vue
+++ b/libs/src/ui/element/List/List.vue
@@ -4,6 +4,7 @@ import ListItem from "@/ui/element/List/ListItem.vue";
 const props = defineProps({
     dataSource: {
         type: Object,
+	    required: true,
     },
     hasOutline: {
 		type: Boolean,
@@ -11,6 +12,7 @@ const props = defineProps({
 	},
 	className: {
 		type: String,
+		default: "",
 	},
 })
 </script>
@@ -22,7 +24,14 @@ const props = defineProps({
 		'ded-outline': props.hasOutline,
 		[props.className]: !!props.className }"
 	>
-		<slot></slot>
+		<ListItem
+			v-for="(item, index) in props.dataSource"
+			:key="index"
+			:label="item.label"
+			:value="item.value"
+			:href="item.href"
+			:prefix="item.prefix"
+		></ListItem>
 	</ul>
 </template>
 

--- a/libs/src/ui/element/Menu/Menu.vue
+++ b/libs/src/ui/element/Menu/Menu.vue
@@ -1,6 +1,5 @@
 <script setup>
 import MenuItem from "./MenuItem.vue";
-import Icon from "@/ui/element/Icon/Icon.vue";
 import { ref } from "vue";
 
 let router;

--- a/libs/src/ui/element/Menu/MenuItem.vue
+++ b/libs/src/ui/element/Menu/MenuItem.vue
@@ -1,5 +1,4 @@
 <script setup>
-import { ref } from "vue";
 import Icon from "@/ui/element/Icon/Icon.vue";
 
 // 定義 Props
@@ -37,17 +36,24 @@ const getComponentType = (item) => {
 const handleItemClick = (item, event) => {
 	emit("itemClick", { item, event });
 };
+
+// 切換展開/收起狀態
+const toggleExpand = (item) => {
+	// 切換當前項目的展開狀態
+	props.expandedItems[item.path] = !props.expandedItems[item.path];
+};
 </script>
+
 
 <template>
 	<li class="ded-nav-item">
 		<!-- 動態組件切換 router-link 或 a -->
+		<!--@click.stop="handleItemClick(props.item, $event)"-->
 		<component
 			:is="getComponentType(props.item)"
 			:to="props.useRouter ? props.item.path : undefined"
 			:href="!props.useRouter ? props.item.path : undefined"
 			class="ded-nav-item-link"
-			@click.stop="handleItemClick(props.item, $event)"
 			:style="`color:${props.color}`"
 		>
 			<!-- 圖標 -->
@@ -68,7 +74,10 @@ const handleItemClick = (item, event) => {
 
 		<!-- 展開圖標 -->
 		<template v-if="!props.isCollapsed && props.item.children">
-			<div class="ded-nav-item-arrow">
+			<div
+				class="ded-nav-item-arrow"
+				@click.stop="toggleExpand(props.item)"
+			>
 				<Icon
 					size="24"
 					name="arrow_down"


### PR DESCRIPTION
🆙update：Accordion

- 同步學長 CSS
- 改寫新的 HTML 結構（Amos 版）
- 重寫 storybook

🆙update：AvatarGroup

- class name 多了 text-large  (20241209 done)
- 程式運作方式，要改成跟 kevin 一樣變數 number 不轉 string (20241209 done)
- 採用 list 組件，請參考 Kevin 的 HTML 結構 (20241209 done)

🆙update：Dialog

- 參考 Kevin 的呈現方式 (20241209 done)
- class 變更 (20241209 done)
- 變更色彩為 primary (20241209 done) -「Title」不用給標題標籤 (20241209 done)
- 點擊按鈕後跳出 alert 讓開發者可以知道目前點擊到的項目，避免誤解是其他物件的事件導致關閉 dialog (20241209 done)
- 改「header」，描述改「標題」 (20241209 done)
- 改「content」，描述改「內容」 (20241209 done)
- 改「footer」，描述改「附註」 (20241209 done)
- 參照 kevin 的參數製作 (20241209 done) (vue 版 isOpen 統一由 compoasable 控制 因此不會出現在 props 中～～ )

🆙update：Divider

- 同步學長 CSS
- None 的 N 改 小寫「n」 (20241209 done)
- 直式的把線添加 min-height: 5em (20241209 done)

🆙update：List

- dataSource 加上必填星號 (20241209 done)
- 選單樣式壞了，請修正 (20241209 done)

🆙update：Input

- 輸入資料後這邊的行為應該會一致出現「Ｘ」，但密碼則會出現「刪除及眼睛」圖示(20241209 done)
